### PR TITLE
fix: initialize websocket issuer in dev server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.0.0",
         "@lvce-editor/package-extension": "^3.2.0",
-        "@lvce-editor/server": "^0.96.12",
-        "@lvce-editor/shared-process": "^0.96.12",
+        "@lvce-editor/server": "^0.99.9",
+        "@lvce-editor/shared-process": "^0.99.9",
         "@lvce-editor/test-syntax-highlighting": "^1.3.0",
         "eslint": "^10.8.0",
         "execa": "^9.6.1",
@@ -1517,9 +1517,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.25.0.tgz",
-      "integrity": "sha512-zgpiSbpQgA07YeiQSzApidBUB9DwenxBksXafJbehbxoNXfqNw2tDiZLifd5Y09PGz/cJhebVQCU2jvw55c4SA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
+      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1675,9 +1675,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.12.tgz",
-      "integrity": "sha512-ERncFru8iwPAn8xHjHYBXnyOlDL5RU4uUbKFqCkvhfCG8v2Anmz1ilPK25kQxKXUAdTY7hzX5yylgeCACzH5DA==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.10.tgz",
+      "integrity": "sha512-yEY6jkgQa75V98cu1ACYCAny513QTMWbC7X7nO//YAEf8ylykCHgS1m7Pm1PdA1A3b7YWbSoxgdzdL7JT0nbBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1691,9 +1691,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
-      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2039,9 +2039,9 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
-      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
+      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2060,14 +2060,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.12.tgz",
-      "integrity": "sha512-XHvSr501fv/0MIbJXSzIMrLDq4djzRaLlHewKMlGtr57/Btz/atqVeb5g8wbsLS+HLdd9hQOVZM1LrGEvaHiRA==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.10.tgz",
+      "integrity": "sha512-KA3/DXuvLVcKA+qJ8LtIe7l0BUpnaKtwWFjETOZCMDV9ZPH3bkh8Pzs3ZXvlhr3bODVey9LaHMyFsVmBjZjYfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.96.12",
-        "@lvce-editor/static-server": "0.96.12"
+        "@lvce-editor/shared-process": "0.99.10",
+        "@lvce-editor/static-server": "0.99.10"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2077,14 +2077,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.12.tgz",
-      "integrity": "sha512-ZdyOoNfEaHYPPEYDSuoKuMr9waXTzLwrAHxKj/sC27L9oLzP/CL2HW7iQosJRorTwTtfpm9l/k3y7KYrR8M6Tg==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.10.tgz",
+      "integrity": "sha512-J6OG6o6cNnXRDaP8/TXNazFw2G8+6Dm90B5U/Rg2w21OebcVKvQO5x+CE4pwoOV7/rrC0H8ZeUh5QuyvSu06sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.96.12",
+        "@lvce-editor/extension-host-helper-process": "0.99.10",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -2101,13 +2101,13 @@
       },
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-system-process": "5.12.0",
         "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/search-process": "15.7.0",
         "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.12.tgz",
-      "integrity": "sha512-9hMcQbGGTJYknInPdjetwMT9lUe2n/nyAfoPM0rylzh9h1Is7FcQXdot+XQKz8Zx45j344niQC+z+O1nCZfwnw==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.10.tgz",
+      "integrity": "sha512-f0/HUo95CqeOgId1Kn8colspaGqDyAIYApW0TSilxh6vEhLes+dtaZDx8Lg5LulLTzQRCtDGqz3LT0TkmzUBeA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4185,17 +4185,6 @@
         "node-addon-api": "7.1.0"
       }
     },
-    "node_modules/@vscode/windows-process-tree/node_modules/node-addon-api": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^16 || ^18 || >= 20"
-      }
-    },
     "node_modules/@zkochan/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
@@ -4445,9 +4434,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6192,6 +6181,22 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6415,9 +6420,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8342,12 +8347,15 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
     },
     "node_modules/node-pty": {
       "version": "1.1.0-beta34",
@@ -8662,9 +8670,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -9063,22 +9071,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/rename-overwrite/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/reserved-identifiers": {
@@ -10106,9 +10098,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.0.0",
     "@lvce-editor/package-extension": "^3.2.0",
-    "@lvce-editor/server": "^0.96.12",
-    "@lvce-editor/shared-process": "^0.96.12",
+    "@lvce-editor/server": "^0.99.9",
+    "@lvce-editor/shared-process": "^0.99.9",
     "@lvce-editor/test-syntax-highlighting": "^1.3.0",
     "eslint": "^10.8.0",
     "execa": "^9.6.1",


### PR DESCRIPTION
Updates the LVCE server and shared process together to the safe 0.99.9 line. This prevents root workbench navigation from bypassing WebSocket issuer initialization while keeping static export aligned with the server runtime.

Validation:
- 29,892 syntax-highlighting tests pass
- static site export passes
- lint and formatting pass
- three root navigation requests return distinct 43-character WebSocket issuers